### PR TITLE
update docs and docker-compose cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This setup uses Maria DB and creates a volume to store uploaded files.
 
 See [here](https://github.com/apigee/apigee-devportal-kickstart-drupal) for the Drupal Installation Profile that this image is based on.
 
+## Prerequisites
+
+- Apigee Organization
+- `docker` and `docker-compose` installed
+
 ## Features
 - Apigee Kickstart profile installed
 - Drupal REST UI installed

--- a/run.sh
+++ b/run.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-AUTO_INSTALL_PORTAL=false docker compose up --no-build
+AUTO_INSTALL_PORTAL=false docker-compose up --no-build

--- a/start.sh
+++ b/start.sh
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-AUTO_INSTALL_PORTAL=true docker compose up --build
+AUTO_INSTALL_PORTAL=true docker-compose up --build


### PR DESCRIPTION
Not all docker distributions contain docker compose. E.g. on linux...

```
# get latest stable docker
curl https://get.docker.com | sh
docker compose
```

` docker: 'compose' is not a docker command`

So the scripts didn't work. Instead we should assume that `docker-compose` is installed