### PR TITLE
fix dbms binary

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     - MYSQL_PASSWORD=passw0rd
     - MYSQL_ROOT_PASSWORD=rootpasswd
     healthcheck:
-      test: [ "CMD-SHELL", 'mysql --database=$$MYSQL_DATABASE --password=$$MYSQL_ROOT_PASSWORD --execute="show tables;" --skip-column-names -B' ]
+      test: [ "CMD-SHELL", 'mariadb --database=$$MYSQL_DATABASE --password=$$MYSQL_ROOT_PASSWORD --execute="show tables;" --skip-column-names -B' ]
       interval: 10s
       timeout: 10s
       retries: 6


### PR DESCRIPTION
This fixes the failing container health check. As the DBMS is based upon Maria DB, the correct name of the binary is `mariadb`. With that, the system now starts up correctly.